### PR TITLE
User fonts

### DIFF
--- a/docs/FONTS.md
+++ b/docs/FONTS.md
@@ -1803,7 +1803,7 @@ BananaUtils.bananaify("Hello, World!", Font.FOUR_TOPS);
 Fraktur
 
 ```java
-BananaUtils.bananaify("Hello, World!",Font.FRAKTUR);
+BananaUtils.bananaify("Hello, World!", Font.FRAKTUR);
 ```
 
 ```
@@ -3178,7 +3178,7 @@ BananaUtils.bananaify("Hello, World!", Font.PEPPER);
 Poison
 
 ```java
-BananaUtils.bananaify("Hello, World!",Font.POISON);
+BananaUtils.bananaify("Hello, World!", Font.POISON);
 ```
 
 ```
@@ -3653,7 +3653,7 @@ BananaUtils.bananaify("Hello, World!", Font.SMALL_KEYBOARD);
 Small Poison
 
 ```java
-BananaUtils.bananaify("Hello, World!",Font.SMALL_POISON);
+BananaUtils.bananaify("Hello, World!", Font.SMALL_POISON);
 ```
 
 ```

--- a/src/main/java/io/leego/banana/BananaUtils.java
+++ b/src/main/java/io/leego/banana/BananaUtils.java
@@ -190,7 +190,7 @@ public final class BananaUtils {
         List<String> data = new ArrayList<>();
         String path = font.getFilename();
 
-        try (InputStream resourceStream = BananaUtils.class.getClassLoader().getResourceAsStream(path);
+        try (InputStream resourceStream = font.getResourceStream();
              InputStream inputStream = unwrapZippedFontIfNecessary(resourceStream)) {
             if (inputStream == null) {
                 return null;

--- a/src/main/java/io/leego/banana/BananaUtils.java
+++ b/src/main/java/io/leego/banana/BananaUtils.java
@@ -26,7 +26,7 @@ public final class BananaUtils {
      * Returns all fonts.
      * @return all fonts.
      */
-    public static List<FontSpec> fonts() {
+    public static List<Font> fonts() {
         return Constants.FONTS;
     }
 
@@ -56,7 +56,7 @@ public final class BananaUtils {
      * @param font the specified font.
      * @return the FIGlet of the text.
      */
-    public static String bananaify(String text, Font font) {
+    public static String bananaify(String text, FontSpec font) {
         return bananaify(text, font, null, null);
     }
 
@@ -68,7 +68,7 @@ public final class BananaUtils {
      * @param verticalLayout   the vertical layout.
      * @return the FIGlet of the text.
      */
-    public static String bananaify(String text, Font font, Layout horizontalLayout, Layout verticalLayout) {
+    public static String bananaify(String text, FontSpec font, Layout horizontalLayout, Layout verticalLayout) {
         String[] lines = generateFiglet(text, font, horizontalLayout, verticalLayout);
         if (lines == null || lines.length == 0) {
             return EMPTY;
@@ -148,7 +148,7 @@ public final class BananaUtils {
      * @param verticalLayout   the vertical layout.
      * @return the FIGlet of the text.
      */
-    public static String[] generateFiglet(String text, Font font, Layout horizontalLayout, Layout verticalLayout) {
+    public static String[] generateFiglet(String text, FontSpec font, Layout horizontalLayout, Layout verticalLayout) {
         if (text == null) {
             return new String[0];
         }
@@ -169,7 +169,7 @@ public final class BananaUtils {
         return output;
     }
 
-    private static Meta getMeta(Font font) {
+    private static Meta getMeta(FontSpec font) {
         if (font == null) {
             font = Constants.DEFAULT_FONT;
         }
@@ -185,7 +185,7 @@ public final class BananaUtils {
         return null;
     }
 
-    private static Meta buildMeta(Font font) {
+    private static Meta buildMeta(FontSpec font) {
         // Reads file content.
         List<String> data = new ArrayList<>();
         String path = font.getFilename();

--- a/src/main/java/io/leego/banana/BananaUtils.java
+++ b/src/main/java/io/leego/banana/BananaUtils.java
@@ -1,7 +1,19 @@
 package io.leego.banana;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PushbackInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.zip.ZipEntry;
@@ -28,6 +40,54 @@ public final class BananaUtils {
      */
     public static List<Font> fonts() {
         return Constants.FONTS;
+    }
+
+    public static FontSpec filesystemFont(final String name, final String path) {
+        return new FontSpec() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getFilename() {
+                return path;
+            }
+
+            @Override
+            public Charset getCharset() {
+                return StandardCharsets.UTF_8;
+            }
+
+            @Override
+            public InputStream getResourceStream() throws IOException {
+                return Files.newInputStream(Paths.get(path));
+            }
+        };
+    }
+
+    public static FontSpec classpathFont(final ClassLoader classLoader, final String name, final String fontPath) {
+        return new FontSpec() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getFilename() {
+                return fontPath;
+            }
+
+            @Override
+            public Charset getCharset() {
+                return StandardCharsets.UTF_8;
+            }
+
+            @Override
+            public InputStream getResourceStream() {
+                return classLoader.getResourceAsStream(fontPath);
+            }
+        };
     }
 
     /**

--- a/src/main/java/io/leego/banana/BananaUtils.java
+++ b/src/main/java/io/leego/banana/BananaUtils.java
@@ -17,7 +17,7 @@ import java.util.zip.ZipInputStream;
 public final class BananaUtils {
     private static final String EMPTY = "";
     private static final String BLANK = " ";
-    private static final ConcurrentMap<Font, Meta> cache = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<FontSpec, Meta> cache = new ConcurrentHashMap<>();
 
     private BananaUtils() {
     }
@@ -26,7 +26,7 @@ public final class BananaUtils {
      * Returns all fonts.
      * @return all fonts.
      */
-    public static List<Font> fonts() {
+    public static List<FontSpec> fonts() {
         return Constants.FONTS;
     }
 
@@ -188,7 +188,7 @@ public final class BananaUtils {
     private static Meta buildMeta(Font font) {
         // Reads file content.
         List<String> data = new ArrayList<>();
-        String path = Constants.FONT_DIR_PATH + font.getFilename();
+        String path = font.getFilename();
 
         try (InputStream resourceStream = BananaUtils.class.getClassLoader().getResourceAsStream(path);
              InputStream inputStream = unwrapZippedFontIfNecessary(resourceStream)) {

--- a/src/main/java/io/leego/banana/Constants.java
+++ b/src/main/java/io/leego/banana/Constants.java
@@ -1,6 +1,7 @@
 package io.leego.banana;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -8,14 +9,12 @@ import java.util.List;
  * @author Yihleego
  */
 public final class Constants {
-    public static final String ROOT_DIR_PATH = "banana";
-    public static final String FONT_DIR_PATH = ROOT_DIR_PATH + "/fonts/";
     public static final int INVALID = 0;
     public static final int VALID = 1;
     public static final int END = 2;
     public static final Font DEFAULT_FONT = Font.STANDARD;
     public static final List<Integer> CODES;
-    public static final List<Font> FONTS;
+    public static final List<FontSpec> FONTS;
 
     static {
         CODES = Collections.unmodifiableList(codes());
@@ -36,8 +35,8 @@ public final class Constants {
         return codes;
     }
 
-    private static List<Font> fonts() {
-        List<Font> fonts = new ArrayList<>(Font.values().length);
+    private static List<FontSpec> fonts() {
+        List<FontSpec> fonts = new ArrayList<>(Font.values().length);
         Collections.addAll(fonts, Font.values());
         return fonts;
     }

--- a/src/main/java/io/leego/banana/Constants.java
+++ b/src/main/java/io/leego/banana/Constants.java
@@ -14,7 +14,7 @@ public final class Constants {
     public static final int END = 2;
     public static final Font DEFAULT_FONT = Font.STANDARD;
     public static final List<Integer> CODES;
-    public static final List<FontSpec> FONTS;
+    public static final List<Font> FONTS;
 
     static {
         CODES = Collections.unmodifiableList(codes());
@@ -35,8 +35,8 @@ public final class Constants {
         return codes;
     }
 
-    private static List<FontSpec> fonts() {
-        List<FontSpec> fonts = new ArrayList<>(Font.values().length);
+    private static List<Font> fonts() {
+        List<Font> fonts = new ArrayList<>(Font.values().length);
         Collections.addAll(fonts, Font.values());
         return fonts;
     }

--- a/src/main/java/io/leego/banana/Font.java
+++ b/src/main/java/io/leego/banana/Font.java
@@ -326,6 +326,7 @@ public enum Font implements FontSpec {
         return FONT_DIR_PATH + filename;
     }
 
+    @Override
     public Charset getCharset() {
         return StandardCharsets.UTF_8;
     }

--- a/src/main/java/io/leego/banana/Font.java
+++ b/src/main/java/io/leego/banana/Font.java
@@ -1,5 +1,6 @@
 package io.leego.banana;
 
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -323,12 +324,17 @@ public enum Font implements FontSpec {
 
     @Override
     public String getFilename() {
-        return FONT_DIR_PATH + filename;
+        return filename;
     }
 
     @Override
     public Charset getCharset() {
         return StandardCharsets.UTF_8;
+    }
+
+    @Override
+    public InputStream getResourceStream() {
+        return Font.class.getClassLoader().getResourceAsStream(FONT_DIR_PATH + filename);
     }
 
     private static final Map<String, FontSpec> map = new HashMap<>(64);

--- a/src/main/java/io/leego/banana/Font.java
+++ b/src/main/java/io/leego/banana/Font.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * @author Yihleego
  */
-public enum Font {
+public enum Font implements FontSpec {
     ONE_ROW("1Row", "1Row.flf"),
     THREE_D("3-D", "3-D.flf"),
     THREE_D_ASCII("3D-ASCII", "3D-ASCII.flf"),
@@ -304,6 +304,10 @@ public enum Font {
     SMALL_ASCII9("Small ASCII 9", "smascii9.tlf"),
     SMALL_ASCII12("Small ASCII 12", "smascii12.tlf"),
     ;
+
+    public static final String ROOT_DIR_PATH = "banana";
+    public static final String FONT_DIR_PATH = ROOT_DIR_PATH + "/fonts/";
+
     private final String name;
     private final String filename;
 
@@ -312,19 +316,21 @@ public enum Font {
         this.filename = filename;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public String getFilename() {
-        return filename;
+        return FONT_DIR_PATH + filename;
     }
 
     public Charset getCharset() {
         return StandardCharsets.UTF_8;
     }
 
-    private static final Map<String, Font> map = new HashMap<>(64);
+    private static final Map<String, FontSpec> map = new HashMap<>(64);
 
     static {
         for (Font e : values()) {
@@ -332,7 +338,7 @@ public enum Font {
         }
     }
 
-    public static Font get(String name) {
+    public static FontSpec get(String name) {
         return map.get(name);
     }
 

--- a/src/main/java/io/leego/banana/FontSpec.java
+++ b/src/main/java/io/leego/banana/FontSpec.java
@@ -1,5 +1,7 @@
 package io.leego.banana;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 
@@ -9,4 +11,6 @@ public interface FontSpec {
     String getFilename();
 
     Charset getCharset();
+
+    InputStream getResourceStream() throws IOException;
 }

--- a/src/main/java/io/leego/banana/FontSpec.java
+++ b/src/main/java/io/leego/banana/FontSpec.java
@@ -1,0 +1,9 @@
+package io.leego.banana;
+
+import java.nio.file.Path;
+
+public interface FontSpec {
+    String getName();
+
+    String getFilename();
+}

--- a/src/main/java/io/leego/banana/FontSpec.java
+++ b/src/main/java/io/leego/banana/FontSpec.java
@@ -1,9 +1,12 @@
 package io.leego.banana;
 
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 
 public interface FontSpec {
     String getName();
 
     String getFilename();
+
+    Charset getCharset();
 }

--- a/src/main/java/io/leego/banana/Meta.java
+++ b/src/main/java/io/leego/banana/Meta.java
@@ -6,24 +6,24 @@ import java.util.Map;
  * @author Yihleego
  */
 public class Meta {
-    private Font font;
+    private FontSpec fontSpec;
     private Option option;
     private Map<Integer, String[]> figletMap;
     private String comment;
 
-    public Meta(Font font, Option option, Map<Integer, String[]> figletMap, String comment) {
-        this.font = font;
+    public Meta(FontSpec fontSpec, Option option, Map<Integer, String[]> figletMap, String comment) {
+        this.fontSpec = fontSpec;
         this.option = option;
         this.figletMap = figletMap;
         this.comment = comment;
     }
 
-    public Font getFont() {
-        return font;
+    public FontSpec getFont() {
+        return fontSpec;
     }
 
-    public void setFont(Font font) {
-        this.font = font;
+    public void setFont(FontSpec fontSpec) {
+        this.fontSpec = fontSpec;
     }
 
     public Option getOption() {

--- a/src/test/java/io/leego/banana/BananaUtilsTest.java
+++ b/src/test/java/io/leego/banana/BananaUtilsTest.java
@@ -15,7 +15,7 @@ public class BananaUtilsTest {
     public void produce_fonts_md() throws IOException {
         try (PrintWriter w = new PrintWriter(Files.newBufferedWriter(Paths.get("docs/FONTS.md"),
                                                                      StandardCharsets.UTF_8))) {
-            for (Font font : BananaUtils.fonts()) {
+            for (Font font : Font.values()) {
                 String fig_letters = BananaUtils.bananaify("Hello, World!", font);
 
                 w.printf(

--- a/src/test/java/io/leego/banana/BananaUtilsTest.java
+++ b/src/test/java/io/leego/banana/BananaUtilsTest.java
@@ -5,12 +5,13 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import static io.leego.banana.BananaUtils.classpathFont;
+import static io.leego.banana.BananaUtils.filesystemFont;
 
 public class BananaUtilsTest {
 
@@ -44,7 +45,8 @@ public class BananaUtilsTest {
     public void can_pass_user_provided_fonts_on_the_classpath() {
         String renderedText = BananaUtils.bananaify(
                 "custom",
-                classpathFont("1 Row",
+                classpathFont(BananaUtilsTest.class.getClassLoader(),
+                              "1 Row",
                               "banana/fonts/" + "1Row.flf"));
 
         Assert.assertEquals(
@@ -67,53 +69,5 @@ public class BananaUtilsTest {
                 "                      ",
                 renderedText
         );
-    }
-
-    private FontSpec filesystemFont(final String name, final String path) {
-        return new FontSpec() {
-            @Override
-            public String getName() {
-                return name;
-            }
-
-            @Override
-            public String getFilename() {
-                return path;
-            }
-
-            @Override
-            public Charset getCharset() {
-                return StandardCharsets.UTF_8;
-            }
-
-            @Override
-            public InputStream getResourceStream() throws IOException {
-                return Files.newInputStream(Paths.get(path));
-            }
-        };
-    }
-
-    static FontSpec classpathFont(final String name, final String fontPath) {
-        return new FontSpec() {
-            @Override
-            public String getName() {
-                return name;
-            }
-
-            @Override
-            public String getFilename() {
-                return fontPath;
-            }
-
-            @Override
-            public Charset getCharset() {
-                return StandardCharsets.UTF_8;
-            }
-
-            @Override
-            public InputStream getResourceStream() {
-                return this.getClass().getClassLoader().getResourceAsStream(fontPath);
-            }
-        };
     }
 }

--- a/src/test/java/io/leego/banana/BananaUtilsTest.java
+++ b/src/test/java/io/leego/banana/BananaUtilsTest.java
@@ -1,10 +1,12 @@
 package io.leego.banana;
 
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -15,7 +17,7 @@ public class BananaUtilsTest {
     public void produce_fonts_md() throws IOException {
         try (PrintWriter w = new PrintWriter(Files.newBufferedWriter(Paths.get("docs/FONTS.md"),
                                                                      StandardCharsets.UTF_8))) {
-            for (Font font : Font.values()) {
+            for (Font font : BananaUtils.fonts()) {
                 String fig_letters = BananaUtils.bananaify("Hello, World!", font);
 
                 w.printf(
@@ -35,6 +37,37 @@ public class BananaUtilsTest {
                 );
             }
         }
+    }
 
+    @Test
+    public void can_pass_user_provided_fonts_on_the_classpath() {
+        String renderedText = BananaUtils.bananaify(
+                "custom",
+                classpathFont("1 Row",
+                              "banana/fonts/" + "1Row.flf"));
+
+        Assert.assertEquals(
+                "( |_| _\\~ ~|~ () |\\/| \n" +
+                "                      ",
+                renderedText
+        );
+    }
+    static FontSpec classpathFont(final String name, final String fontPath) {
+        return new FontSpec() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getFilename() {
+                return fontPath;
+            }
+
+            @Override
+            public Charset getCharset() {
+                return StandardCharsets.UTF_8;
+            }
+        };
     }
 }

--- a/src/test/java/io/leego/banana/BananaUtilsTest.java
+++ b/src/test/java/io/leego/banana/BananaUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -52,6 +53,46 @@ public class BananaUtilsTest {
                 renderedText
         );
     }
+
+    @Test
+    public void can_pass_user_provided_fonts_file() {
+        String renderedText = BananaUtils.bananaify(
+                "custom",
+                filesystemFont(
+                        "1 Row",
+                        "src/main/resources/banana/fonts/" + "1Row.flf"));
+
+        Assert.assertEquals(
+                "( |_| _\\~ ~|~ () |\\/| \n" +
+                "                      ",
+                renderedText
+        );
+    }
+
+    private FontSpec filesystemFont(final String name, final String path) {
+        return new FontSpec() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getFilename() {
+                return path;
+            }
+
+            @Override
+            public Charset getCharset() {
+                return StandardCharsets.UTF_8;
+            }
+
+            @Override
+            public InputStream getResourceStream() throws IOException {
+                return Files.newInputStream(Paths.get(path));
+            }
+        };
+    }
+
     static FontSpec classpathFont(final String name, final String fontPath) {
         return new FontSpec() {
             @Override
@@ -67,6 +108,11 @@ public class BananaUtilsTest {
             @Override
             public Charset getCharset() {
                 return StandardCharsets.UTF_8;
+            }
+
+            @Override
+            public InputStream getResourceStream() {
+                return this.getClass().getClassLoader().getResourceAsStream(fontPath);
             }
         };
     }


### PR DESCRIPTION
Hi there,

I'd like to propose the following change, allow a consumer to pass his own fonts. E.g.

```java
BananaUtils.bananaify(
                "text",
                MyFont.of("1 Row", "src/main/resources/banana/fonts/" + "1Row.flf"));
```


In order to achieve that, I extracted an interface with a few methods to match the existing Font enum in banana, and one another to allow to pass a font from the filesystem.

```java
public interface FontSpec {
    String getName();

    String getFilename();

    Charset getCharset();

    InputStream getResourceStream() throws IOException;
}
```

Due this change I found it was unwise to keep the two constant `ROOT_DIR_PATH` and `FONT_DIR_PATH` in the `Constants` class, as it makes the relation circular. I hope you're ok with that.

As this projects is compiled with Java 1.7 interface static methods are not available, so I put the static factory method in `BananaUtils` (If moving to Java 8 it could have been something like `FontSpec.of()`).